### PR TITLE
Fix compilation errors in the withinTx section

### DIFF
--- a/en/04_transaction.md
+++ b/en/04_transaction.md
@@ -93,7 +93,7 @@ Note that `localTx` cannot be taken out as a `DBSession` because it is a transac
 
 It runs queries and update operations within an existing transaction. You are responsible for handling the transaction and manage the datasource by yourself.
 
-    using(DB(ConnectionPool.borrow())) { db =>
+    using(DB(ConnectionPool.borrow())) { implicit db =>
       try {
         db.begin() // start of a transaction
 

--- a/ja/04_transaction.md
+++ b/ja/04_transaction.md
@@ -93,7 +93,7 @@ readOnlySession と同様に autoCommitSession もあります。
 
 クエリや更新を既に存在しているトランザクション内で実行します。トランザクションについての操作はすべてライブラリ利用者によって制御される必要があります。
 
-    using(DB(ConnectionPool.borrow())) { db =>
+    using(DB(ConnectionPool.borrow())) { implicit db =>
       try {
         db.begin() // トランザクションの開始
 


### PR DESCRIPTION
Thrown compilation errors when tried the sample code of [`withinTx`](https://github.com/scalikejdbc/scalikejdbc-cookbook/blob/master/ja/04_transaction.md#withintx).

```
Error:(150, 26) could not find implicit value for parameter db: scalikejdbc.DB
          val names = DB withinTx { implicit session =>
Error:(150, 26) not enough arguments for method withinTx: (implicit db: scalikejdbc.DB)List[String].
Unspecified value parameter db.
          val names = DB withinTx { implicit session =>
```

Fix `db` to implicit parameter.