### PR TITLE
Fix compilation errors in the QueryDSL section

### DIFF
--- a/en/05_sql_template.md
+++ b/en/05_sql_template.md
@@ -192,7 +192,7 @@ can be rewritten as below (a Member object extending SQLSyntaxSupport needs to b
 
     object Member extends SQLSyntaxSupport[Member] {
 
-      def insert(id: Long, name: String, memo: Option[String]) = DB.localTx { implicit s =>
+      def create(id: Long, name: String, memo: Option[String]) = DB.localTx { implicit s =>
         val now = DateTime.now
         withSQL {
           insert.into(Member)
@@ -206,8 +206,11 @@ can be rewritten as below (a Member object extending SQLSyntaxSupport needs to b
     val id: Int = 1234
 
     val m = Member.syntax("m")
-    val names = select(m.name).from(Member as m).where.eq(m.id, id).orderBy(m.id).append(ordering)
-      .map(rs => rs.long(m.name)).list.apply()
+    val names = DB.localTx { implicit s =>
+      withSQL {
+        select(m.name).from(Member as m).where.eq(m.id, id).orderBy(m.id).append(ordering)
+      }.map(rs => rs.string(m.name)).list.apply()
+    }
 
 ## Summary
 

--- a/ja/05_sql_template.md
+++ b/ja/05_sql_template.md
@@ -192,7 +192,7 @@ http://scalikejdbc.org/documentation/auto-macros.html
 
     object Member extends SQLSyntaxSupport[Member] {
 
-      def insert(id: Long, name: String, memo: Option[String]) = DB.localTx { implicit s =>
+      def create(id: Long, name: String, memo: Option[String]) = DB.localTx { implicit s =>
         val now = DateTime.now
         withSQL {
           insert.into(Member)
@@ -206,8 +206,11 @@ http://scalikejdbc.org/documentation/auto-macros.html
     val id: Int = 1234
 
     val m = Member.syntax("m")
-    val names = select(m.name).from(Member as m).where.eq(m.id, id).orderBy(m.id).append(ordering)
-      .map(rs => rs.long(m.name)).list.apply()
+    val names = DB.localTx { implicit s =>
+      withSQL {
+        select(m.name).from(Member as m).where.eq(m.id, id).orderBy(m.id).append(ordering)
+      }.map(rs => rs.string(m.name)).list.apply()
+    }
 
 ## まとめ
 


### PR DESCRIPTION
https://github.com/scalikejdbc/scalikejdbc-cookbook/blob/master/ja/05_sql_template.md#querydsl

- Rename `insert` function to `create`.
- Surround DSL with `DB.localTx` and `withSQL`.
- Change `rs.long(m.name)` to `rs.string(m.name)`.