### PR TITLE
Fix play db setting name (db.user => db.username). and update play la…

### DIFF
--- a/en/08_unittest.md
+++ b/en/08_unittest.md
@@ -9,7 +9,7 @@ scalikejdbc-test is a sub project which provides supports for both of ScalaTest 
     val appDependencies = Seq(
       "org.scalikejdbc"   %% "scalikejdbc"      % "3.2.+",
       "org.scalikejdbc"   %% "scalikejdbc-test" % "3.2.+"   % "test",
-      "org.scalatest"     %% "scalatest"        % "3.0.+"   % "test"
+      "org.scalatest"     %% "scalatest"        % "3.0.+"   % "test",
       "org.specs2"        %% "specs2-core"      % "3.8.9"   % "test"
     )
 
@@ -23,7 +23,7 @@ Preparing a trait which set up a ConnectionPool and mixing in the trait is a goo
         // https://github.com/typesafehub/config
         val config = ConfigFactory.load()
         val url = config.getString("jdbc.url")
-        val user = config.getString("jdbc.user")
+        val user = config.getString("jdbc.username")
         val password = config.getString("jdbc.password")
         ConnectionPool.singleton(url, user, password)
       }
@@ -56,7 +56,7 @@ Play's configuration uses Typesafe Config library. When the configuration is def
 
     db.default.url="jdbc:h2:mem:sample1"
     db.default.driver="org.h2.Driver"
-    db.default.user="sa"
+    db.default.username="sa"
     db.default.password="secret"
 
 You can easily load the settings while initializing the code.
@@ -68,12 +68,12 @@ To load multiple configurations:
 
     db.foo.url="jdbc:h2:mem:sample2"
     db.foo.driver="org.h2.Driver"
-    db.foo.user="sa"
+    db.foo.username="sa"
     db.foo.password="secret"
 
     db.bar.url="jdbc:h2:mem:sample2"
     db.bar.driver="org.h2.Driver"
-    db.bar.user="sa2"
+    db.bar.username="sa2"
     db.bar.password="secret2"
 
 Call `DBs.setupAll`.

--- a/en/10_play.md
+++ b/en/10_play.md
@@ -2,7 +2,7 @@
 
 [Play! Framework](http://www.playframework.com/)  is originally a Java Web framework heavily insired by Ruby on Rails. Since version 2.0, the framework was rewritten in Scala and became an Akka-based framework.
 
-As of May 2017, the latest version of Play Framework is 2.5.14.
+As of May 2020, the latest version of Play Framework is 2.8.1.
 
 [http://www.playframework.com/](http://www.playframework.com/)
 
@@ -48,7 +48,7 @@ You can use the standard configuration of Play apps. Only the attributes for Con
     # DB to connect
     db.default.driver=org.h2.Driver
     db.default.url="jdbc:h2:mem:play"
-    db.default.user="sa"
+    db.default.username="sa"
     db.default.password="sa"
 
     # Extra configuration, ScalikeJDBC specific
@@ -61,7 +61,7 @@ For non-default ones, specify the name like `another` in the following sample:
     # NamedDB('another)
     db.another.driver=org.h2.Driver
     db.another.url="jdbc:h2:mem:play"
-    db.another.user="sa"
+    db.another.usename="sa"
     db.another.password="sa"
 
     # Extra configuration, ScalikeJDBC specific

--- a/ja/08_unittest.md
+++ b/ja/08_unittest.md
@@ -9,7 +9,7 @@ ScalaTest と specs2 にそれぞれ同等のサポート機能を提供する�
     val appDependencies = Seq(
       "org.scalikejdbc"   %% "scalikejdbc"      % "3.2.+",
       "org.scalikejdbc"   %% "scalikejdbc-test" % "3.2.+"   % "test",
-      "org.scalatest"     %% "scalatest"        % "3.0.+"   % "test"
+      "org.scalatest"     %% "scalatest"        % "3.0.+"   % "test",
       "org.specs2"        %% "specs2-core"      % "3.8.9"   % "test"
     )
 
@@ -23,7 +23,7 @@ ConnectionPool を設定する trait を用意して mixin する方法があり
         // https://github.com/typesafehub/config
         val config = ConfigFactory.load()
         val url = config.getString("jdbc.url")
-        val user = config.getString("jdbc.user")
+        val user = config.getString("jdbc.username")
         val password = config.getString("jdbc.password")
         ConnectionPool.singleton(url, user, password)
       }
@@ -56,7 +56,7 @@ Play の設定は Typesafe Config になっていますが、それ以外のア�
 
     db.default.url="jdbc:h2:mem:sample1"
     db.default.driver="org.h2.Driver"
-    db.default.user="sa"
+    db.default.username="sa"
     db.default.password="secret"
 
 初期化処理で以下のようにして簡単に読み込むことができます。
@@ -68,12 +68,12 @@ Play の設定は Typesafe Config になっていますが、それ以外のア�
 
     db.foo.url="jdbc:h2:mem:sample2"
     db.foo.driver="org.h2.Driver"
-    db.foo.user="sa"
+    db.foo.username="sa"
     db.foo.password="secret"
 
     db.bar.url="jdbc:h2:mem:sample2"
     db.bar.driver="org.h2.Driver"
-    db.bar.user="sa2"
+    db.bar.username="sa2"
     db.bar.password="secret2"
 
 DBs.setupAll を呼び出します。

--- a/ja/10_play.md
+++ b/ja/10_play.md
@@ -2,7 +2,7 @@
 
 [Play Framework](http://www.playframework.com/) は元々は Ruby on Rails に強く影響された Java 向けの Web アプリケーションフレームワークでしたが、version 2.0 からは Akka ベースのアーキテクチャに書き直され、Scala での利用を基本とするフレームワークに生まれ変わりました。
 
-2017 年 5 月時点で最新の安定バージョンは 2.5.14 です。
+2020 年 5 月時点で最新の安定バージョンは 2.8.1 です。
 
 [http://www.playframework.com/](http://www.playframework.com/)
 
@@ -48,7 +48,7 @@ Play の標準の DB プラグインと同じキー名で接続設定を記述�
     # DB で接続する DB
     db.default.driver=org.h2.Driver
     db.default.url="jdbc:h2:mem:play"
-    db.default.user="sa"
+    db.default.username="sa"
     db.default.password="sa"
 
     # ScalikeJDBC 独自の ConnectionPool 設定
@@ -61,7 +61,7 @@ default 以外は以下のように記述します。
     # NamedDB('another) で接続する DB
     db.another.driver=org.h2.Driver
     db.another.url="jdbc:h2:mem:play"
-    db.another.user="sa"
+    db.another.username="sa"
     db.another.password="sa"
 
     # ScalikeJDBC 独自の ConnectionPool 設定


### PR DESCRIPTION
I modified setting's name of play db in chapter 10.
`db.xxxx.user` used until play 2.3, `db.xxxx.username` used from 2.4.
(however we can use both parameters, a warning appear)

moreover, update the latest version of play.